### PR TITLE
Show only 50 TextMarkers at a time in data input

### DIFF
--- a/src/components/DataInput.vue
+++ b/src/components/DataInput.vue
@@ -31,6 +31,7 @@ export default Vue.extend({
     codeMirror: null as EditorFromTextArea|null,
     textMarkers: [] as CodeMirror.TextMarker[],
     parser: new Parser(),
+    maxMarkers: 50,
   }),
   watch: {
     regexString(): void {
@@ -104,6 +105,9 @@ export default Vue.extend({
       const doc = this.codeMirror.getDoc();
       this.parser.parse(this.value).forEach((regExpMatchArray, regExpMatchArrayIndex) => {
         if (this.codeMirror === null) {
+          return;
+        }
+        if (regExpMatchArrayIndex > this.maxMarkers) {
           return;
         }
         const indexStart = regExpMatchArray.index;


### PR DESCRIPTION
The lag is quite noticeable when attempting to create a regular expression with data already entered. See #27.

This is a short term fix to limit the number of markers matched.

An alternative short term fix considered was to debounce, but this just makes the experience feel sluggish.