### PR TITLE
Add map projection settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,6 +2200,12 @@
       "integrity": "sha1-5IbQ2XOW15vu3QpuM/RTT/a0lz4=",
       "dev": true
     },
+    "@types/proj4": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.0.tgz",
+      "integrity": "sha512-9bR9qvg4wZE6UiIlmhodCOZ2r38SeN8T35SsmMDuIMfACxxaMvIwiwoTJnEA9f/KEhL+BQSuD+arbZucUzYu7w==",
+      "dev": true
+    },
     "@types/q": {
       "version": "1.5.2",
       "resolved": "https://registry.npm.taobao.org/@types/q/download/@types/q-1.5.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13989,6 +13989,11 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
+    "mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha1-+5FYjnjJACVnI5XLQLJffNatGCk="
+    },
     "microevent.ts": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/microevent.ts/-/microevent.ts-0.1.1.tgz",
@@ -15746,6 +15751,15 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "proj4": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.6.0.tgz",
+      "integrity": "sha512-ll2WyehUFOyzEZtN8hAiOTmZpuDCN5V+4A/HjhPbhlwVwlsFKnIHSZ3l3uhzgDndHjoL2MyERFGe9VmXN4rYUg==",
+      "requires": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.2.0"
+      }
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -18978,6 +18992,11 @@
       "resolved": "https://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
+    },
+    "wkt-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.2.3.tgz",
+      "integrity": "sha512-s7zrOedGuHbbzMaQOuf8HacuCYp3LmmrHjkkN//7UEAzsYz7xJ6J+j/84ZWZkQcrRqi3xXyuc4odPHj7PEB0bw=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7193,6 +7193,11 @@
       "integrity": "sha1-aNYITKsbB5dnVA2A5Wo5tCPkq/Q=",
       "dev": true
     },
+    "epsg-index": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/epsg-index/-/epsg-index-1.0.0.tgz",
+      "integrity": "sha512-7EcEC97QaNzSKakpc6HgVdxBc7G1vEuNRIygjVXBvrLA+t8+4QlK6jisf0g552eSzBIAkx0IRmd/CWJKLc/W5A=="
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npm.taobao.org/errno/download/errno-0.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "codemirror": "^5.51.0",
     "core-js": "^3.6.4",
     "debounce": "^1.2.0",
+    "proj4": "^2.6.0",
     "regexp": "^1.0.0",
     "vue": "^2.6.10",
     "vue-class-component": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/debounce": "^1.2.0",
     "@types/jest": "^25.1.1",
+    "@types/proj4": "^2.5.0",
     "@types/vue-clickaway": "^2.2.0",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@vue/cli-plugin-babel": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "codemirror": "^5.51.0",
     "core-js": "^3.6.4",
     "debounce": "^1.2.0",
+    "epsg-index": "^1.0.0",
     "proj4": "^2.6.0",
     "regexp": "^1.0.0",
     "vue": "^2.6.10",

--- a/src/App.vue
+++ b/src/App.vue
@@ -126,7 +126,7 @@ export default Vue.extend({
     data: '',
     projectionEpsgCode: '4326',
     projectionProj4: '',
-    projectionSearchInput: 'TEST',
+    projectionSearchInput: '4326',
     parser: new Parser(),
     parsedData: [] as RegExpMatchArray[],
     allMatchGroupsResult: [] as string[][],
@@ -177,7 +177,6 @@ export default Vue.extend({
 | Bob   | 2020-03-22T19:26:42 | 56.11799 | -3.93653  |
 | Bob   | 2020-03-26T09:46:18 | 55.45705 | -4.63623  |
 +-------+---------------------+----------+-----------+`;
-      this.projectionEpsgCode = '4326';
       this.allGroupSettings = [
         { type: null },
         { type: null },

--- a/src/App.vue
+++ b/src/App.vue
@@ -89,6 +89,7 @@
 </template>
 
 <script lang="ts">
+import proj4 from 'proj4';
 import Vue from 'vue';
 import RegexInput from './components/RegexInput.vue';
 import DataInput from './components/DataInput.vue';
@@ -115,8 +116,8 @@ export default Vue.extend({
   data: () => ({
     regex: '',
     regexFlags: {
-      global: true,
-      multiline: true,
+      global: false,
+      multiline: false,
       insensitive: false,
       singleline: false,
       unicode: false,
@@ -124,9 +125,9 @@ export default Vue.extend({
     } as RegExpFlagsConfig,
     regexHasError: false,
     data: '',
-    projectionEpsgCode: '4326',
+    projectionEpsgCode: '',
     projectionProj4: '',
-    projectionSearchInput: '4326',
+    projectionSearchInput: '',
     parser: new Parser(),
     parsedData: [] as RegExpMatchArray[],
     allMatchGroupsResult: [] as string[][],
@@ -149,6 +150,9 @@ export default Vue.extend({
       this.updateEverything();
     },
     data(): void {
+      this.updateEverything();
+    },
+    projectionProj4(): void {
       this.updateEverything();
     },
     allGroupSettings: {
@@ -183,11 +187,26 @@ export default Vue.extend({
         { type: 'latitude' },
         { type: 'longitude' },
       ];
+      this.projectionEpsgCode = '4326';
+      this.projectionSearchInput = '4326';
+      this.regexFlags = {
+        global: true,
+        multiline: true,
+        insensitive: false,
+        singleline: false,
+        unicode: false,
+        sticky: false,
+      };
     },
     updateEverything(): void {
       this.parsedData = this.parser.parse(this.data);
       this.allMatchGroupsResult = this.parsedData;
-      this.geoJson = GeoJsonGenerator.generate(this.parsedData, this.allGroupSettings);
+      if (this.projectionProj4 === '') {
+        this.geoJson = 'Please select a projection in the settings above. For example: EPSG:4326';
+        return;
+      }
+      const projection = proj4(this.projectionProj4);
+      this.geoJson = GeoJsonGenerator.generate(this.parsedData, this.allGroupSettings, projection);
     },
   },
 });

--- a/src/App.vue
+++ b/src/App.vue
@@ -51,7 +51,17 @@
             :value.sync="data"
           />
 
-          <h2>Step 3. Capture Group Settings</h2>
+          <h2>Step 3. Projection Settings</h2>
+          <p class="body-2">
+            Select the map projection the input data is in.
+            By default, we assume it is latitude/longitude (WGS 84).
+          </p>
+          <ProjectionSelect
+            :epsg.sync="projectionEpsg"
+            :proj4.sync="projectionProj4"
+          />
+
+          <h2>Step 4. Capture Group Settings</h2>
           <p class="body-2">
             For each capture group in the regular expression, select the appropriate type.
           </p>
@@ -79,6 +89,7 @@
 import Vue from 'vue';
 import RegexInput from './components/RegexInput.vue';
 import DataInput from './components/DataInput.vue';
+import ProjectionSelect from './components/ProjectionSelect.vue';
 import GroupSettingsTable from './components/GroupSettingsTable.vue';
 import GeoJsonOutput from './components/GeoJsonOutput.vue';
 import Parser from '@/utils/parser';
@@ -93,6 +104,7 @@ export default Vue.extend({
   components: {
     RegexInput,
     DataInput,
+    ProjectionSelect,
     GroupSettingsTable,
     GeoJsonOutput,
   },
@@ -109,6 +121,8 @@ export default Vue.extend({
     } as RegExpFlagsConfig,
     regexHasError: false,
     data: '',
+    projectionEpsg: '',
+    projectionProj4: '',
     parser: new Parser(),
     parsedData: [] as RegExpMatchArray[],
     allMatchGroupsResult: [] as string[][],
@@ -159,6 +173,7 @@ export default Vue.extend({
 | Bob   | 2020-03-22T19:26:42 | 56.11799 | -3.93653  |
 | Bob   | 2020-03-26T09:46:18 | 55.45705 | -4.63623  |
 +-------+---------------------+----------+-----------+`;
+      this.projectionEpsg = 'EPSG:4326';
       this.allGroupSettings = [
         { type: null },
         { type: null },

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,6 +61,7 @@
           <ProjectionSelect
             :epsg.sync="projectionEpsg"
             :proj4.sync="projectionProj4"
+            :search-input.sync="projectionSearchInput"
           />
 
           <h2>Step 4. Capture Group Settings</h2>
@@ -125,6 +126,7 @@ export default Vue.extend({
     data: '',
     projectionEpsg: '',
     projectionProj4: '',
+    projectionSearchInput: 'TEST',
     parser: new Parser(),
     parsedData: [] as RegExpMatchArray[],
     allMatchGroupsResult: [] as string[][],

--- a/src/App.vue
+++ b/src/App.vue
@@ -59,8 +59,8 @@
             other projection systems.
           </p>
           <ProjectionSelect
-            :epsg.sync="projectionEpsg"
-            :proj4.sync="projectionProj4"
+            :selected-epsg-code.sync="projectionEpsgCode"
+            :selected-proj4.sync="projectionProj4"
             :search-input.sync="projectionSearchInput"
           />
 
@@ -124,7 +124,7 @@ export default Vue.extend({
     } as RegExpFlagsConfig,
     regexHasError: false,
     data: '',
-    projectionEpsg: '',
+    projectionEpsgCode: '4326',
     projectionProj4: '',
     projectionSearchInput: 'TEST',
     parser: new Parser(),
@@ -177,7 +177,7 @@ export default Vue.extend({
 | Bob   | 2020-03-22T19:26:42 | 56.11799 | -3.93653  |
 | Bob   | 2020-03-26T09:46:18 | 55.45705 | -4.63623  |
 +-------+---------------------+----------+-----------+`;
-      this.projectionEpsg = 'EPSG:4326';
+      this.projectionEpsgCode = '4326';
       this.allGroupSettings = [
         { type: null },
         { type: null },

--- a/src/App.vue
+++ b/src/App.vue
@@ -55,6 +55,8 @@
           <p class="body-2">
             Select the map projection the input data is in.
             By default, we assume it is latitude/longitude (WGS 84).
+            Search <a href="https://epsg.io">epsg.io</a> for information on
+            other projection systems.
           </p>
           <ProjectionSelect
             :epsg.sync="projectionEpsg"

--- a/src/App.vue
+++ b/src/App.vue
@@ -72,6 +72,7 @@
             <GroupSettingsTable
               :regex-string="!regexHasError ? regex : null"
               :regex-match-all-result="allMatchGroupsResult"
+              :is-wgs84="projectionEpsgCode === '4326'"
               :all-group-settings.sync="allGroupSettings"
             />
           </div>
@@ -184,8 +185,8 @@ export default Vue.extend({
       this.allGroupSettings = [
         { type: null },
         { type: null },
-        { type: 'latitude' },
-        { type: 'longitude' },
+        { type: 'y' },
+        { type: 'x' },
       ];
       this.projectionEpsgCode = '4326';
       this.projectionSearchInput = '4326';

--- a/src/components/GroupSettingsTable.vue
+++ b/src/components/GroupSettingsTable.vue
@@ -129,8 +129,15 @@ export default Vue.extend({
 
         // Update the table with group matches from the parsed input data.
         allGroupMatches.forEach((groupMatches, groupNumber) => {
+          // This can happen when Vue has only updated the regexString prop,
+          // but not the regexMatchAllResult prop. So we just disregard
+          // setting the property.
+          if (groupNumber >= this.items.length) {
+            return;
+          }
           this.items[groupNumber].groupMatches = groupMatches;
         });
+
         // Clear any rows in the table if there aren't any group matches.
         for (
           let groupNumber = allGroupMatches.length;

--- a/src/components/GroupSettingsTable.vue
+++ b/src/components/GroupSettingsTable.vue
@@ -18,6 +18,7 @@
       <td>{{ item.groupNumber }}</td>
       <td>
         <MatchGroupTypeSelect
+          :is-wgs84="isWgs84"
           :value.sync="item.groupSettings.type"
         />
       </td>
@@ -87,6 +88,10 @@ export default Vue.extend({
     regexMatchAllResult: {
       type: Array as () => RegExpMatchArray[],
       default: (): RegExpMatchArray[] => [],
+    },
+    isWgs84: {
+      type: Boolean,
+      default: (): boolean => false,
     },
     allGroupSettings: {
       type: Array as () => GroupSettingsArray,

--- a/src/components/MatchGroupTypeSelect.vue
+++ b/src/components/MatchGroupTypeSelect.vue
@@ -13,23 +13,43 @@
 <script lang="ts">
 import Vue from 'vue';
 
+interface SelectOption {
+  value: string|null;
+  text: string;
+}
+
 export default Vue.extend({
   name: 'MatchGroupTypeSelect',
   props: {
+    isWgs84: {
+      type: Boolean,
+      default: true,
+    },
     value: {
       type: String,
       default: '',
     },
   },
-  data: () => ({
-    options: [
-      { value: null, text: '' },
-      { value: 'longitude', text: 'Longitude (Decimal)' },
-      { value: 'latitude', text: 'Latitude (Decimal)' },
-      { value: 'name', text: 'Category name' },
-      { value: 'time', text: 'Time' },
-    ],
-  }),
+  computed: {
+    options(): SelectOption[] {
+      if (this.isWgs84) {
+        return [
+          { value: null, text: '' },
+          { value: 'x', text: 'Longitude (Decimal)' },
+          { value: 'y', text: 'Latitude (Decimal)' },
+          { value: 'name', text: 'Category name' },
+          { value: 'time', text: 'Time' },
+        ];
+      }
+      return [
+        { value: null, text: '' },
+        { value: 'x', text: 'X Coordinate' },
+        { value: 'y', text: 'Y Coordinate' },
+        { value: 'name', text: 'Category name' },
+        { value: 'time', text: 'Time' },
+      ];
+    },
+  },
   methods: {
     update(value: string): void {
       this.$emit('update:value', value);

--- a/src/components/ProjectionSelect.vue
+++ b/src/components/ProjectionSelect.vue
@@ -106,7 +106,7 @@ export default Vue.extend({
       current: 0,
       selectedName: '',
       maxMatches: 50,
-      projections: Object.values(allEpsgProjections) as Projection[],
+      projections: [] as Projection[],
     };
   },
   computed: {
@@ -178,6 +178,7 @@ export default Vue.extend({
     const selectedProjection = (
       allEpsgProjections as {[key: string]: Projection}
     )[this.selectedEpsgCode];
+    this.projections = Object.values(allEpsgProjections as {[key: string]: Projection});
     this.selectedName = selectedProjection.name;
     this.$emit('update:selectedProj4', selectedProjection.code);
     inputField.value = this.selectedLabel;

--- a/src/components/ProjectionSelect.vue
+++ b/src/components/ProjectionSelect.vue
@@ -1,0 +1,114 @@
+<template>
+  <div class="container">
+    <div class="selected-name">
+      EPSG:4326 - WGS84
+    </div>
+    <input
+      class="search-input"
+      type="text"
+      value="Test"
+      @keydown.enter="enter"
+      @keydown.down="down"
+      @keydown.up="up"
+      @input="change"
+    >
+    <div class="search-button">
+      <font-awesome-icon
+        icon="search"
+      />
+      <font-awesome-icon
+        icon="times-circle"
+      />
+    </div>
+    <div class="search-results">
+      <ul>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faSearch, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+library.add(faSearch);
+library.add(faTimesCircle);
+
+export default Vue.extend({
+  name: 'ProjectionSelect',
+  components: {
+    FontAwesomeIcon,
+  },
+  props: {
+    selection: {
+      type: String,
+      default: '',
+    },
+  },
+  data() {
+    return {
+      searching: false,
+      open: false,
+      current: 0,
+      suggestions: ['123', '4566'],
+    };
+  },
+  computed: {
+    matches(): string[] {
+      return this.suggestions.filter((str) => str.indexOf(this.selection) >= 0);
+    },
+    openSuggestion(): boolean {
+      return this.selection !== ''
+        && this.matches.length !== 0
+        && this.open === true;
+    },
+  },
+  methods: {
+    enter(): void {
+      // this.selection = this.matches[this.current];
+      this.open = false;
+    },
+    up(): void {
+      if (this.current > 0) {
+        this.current -= 1;
+      }
+    },
+    down(): void {
+      if (this.current < this.matches.length - 1) {
+        this.current += 1;
+      }
+    },
+    isActive(index: number): boolean {
+      return index === this.current;
+    },
+    change(): void {
+      if (this.open === false) {
+        this.open = true;
+        this.current = 0;
+      }
+    },
+    // eslint-disable-next-line no-unused-vars
+    suggestionClick(index: number): void {
+      // this.selection = this.matches[index];
+      this.open = false;
+    },
+  },
+});
+</script>
+
+<style scoped>
+.container {
+  box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
+  0 2px 2px 0 rgba(0, 0, 0, 0.14),
+  0 1px 5px 0 rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  padding: 4px;
+  background: #FFFFFF;
+}
+</style>
+
+<style>
+
+</style>

--- a/src/components/ProjectionSelect.vue
+++ b/src/components/ProjectionSelect.vue
@@ -1,28 +1,36 @@
 <template>
-  <div class="container">
-    <div class="selected-name">
-      EPSG:4326 - WGS84
+  <div>
+    <div class="container">
+      <div class="search-button">
+        <font-awesome-icon
+          icon="search"
+        />
+        <font-awesome-icon
+          icon="times-circle"
+          style="display: none"
+        />
+      </div>
+      <input
+        class="search-input"
+        type="text"
+        value="EPSG:4326 - WGS 84"
+        @keydown.enter="enter"
+        @keydown.down="down"
+        @keydown.up="up"
+        @input="change"
+      >
     </div>
-    <input
-      class="search-input"
-      type="text"
-      value="Test"
-      @keydown.enter="enter"
-      @keydown.down="down"
-      @keydown.up="up"
-      @input="change"
-    >
-    <div class="search-button">
-      <font-awesome-icon
-        icon="search"
-      />
-      <font-awesome-icon
-        icon="times-circle"
-      />
-    </div>
-    <div class="search-results">
-      <ul>
-      </ul>
+    <div class="search-results-container">
+      <div class="search-results">
+        <ul>
+          <li>
+            Hello World
+            <font-awesome-icon
+              icon="info-circle"
+            />
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </template>
@@ -30,11 +38,12 @@
 <script lang="ts">
 import Vue from 'vue';
 import { library } from '@fortawesome/fontawesome-svg-core';
-import { faSearch, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
+import { faSearch, faTimesCircle, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 library.add(faSearch);
 library.add(faTimesCircle);
+library.add(faInfoCircle);
 
 export default Vue.extend({
   name: 'ProjectionSelect',
@@ -106,6 +115,55 @@ export default Vue.extend({
   border-radius: 4px;
   padding: 4px;
   background: #FFFFFF;
+}
+
+.search-button {
+  display: inline-block;
+}
+
+.selected-name {
+  display: inline-block;
+}
+
+.search-results-container {
+  position: relative;
+  width: 100%;
+  height: 0;
+}
+
+.search-results {
+  background: #FFF;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+  0 8px 10px 1px rgba(0, 0, 0, 0.14),
+  0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
+  position: absolute;
+  top: 5px;
+  z-index: 10;
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+.search-results ul {
+  list-style: none;
+  padding: 0;
+}
+
+.search-results ul li {
+  cursor: pointer;
+  padding: 2px 8px 2px 8px;
+}
+
+.search-results ul li:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.svg-inline--fa {
+  width: 16px;
+  height: 16px;
+  margin-left: 2px;
+  margin-right: 2px;
+  opacity: 0.8;
 }
 </style>
 

--- a/src/components/ProjectionSelect.vue
+++ b/src/components/ProjectionSelect.vue
@@ -143,7 +143,7 @@ export default Vue.extend({
     const selectedProjection = this.epsgIndex.getProjectionByCode(this.selectedEpsgCode);
     if (selectedProjection !== null) {
       this.selectedName = selectedProjection.name;
-      this.$emit('update:selectedProj4', selectedProjection.code);
+      this.$emit('update:selectedProj4', selectedProjection.proj4);
     }
     inputField.value = this.selectedLabel;
   },

--- a/src/components/ProjectionSelect.vue
+++ b/src/components/ProjectionSelect.vue
@@ -6,7 +6,7 @@
       <input
         class="search-input"
         type="text"
-        placeholder="Enter an EPSG code or name"
+        placeholder="Enter an EPSG code or name..."
         @focusin="focusin"
         @keydown.enter="enter"
         @keydown.down="down"
@@ -113,7 +113,7 @@ export default Vue.extend({
   computed: {
     selectedLabel(): string {
       if (this.selectedEpsgCode === '') {
-        return 'Select a projection...';
+        return '';
       }
       return `EPSG:${this.selectedEpsgCode} - ${this.selectedName}`;
     },
@@ -256,6 +256,7 @@ export default Vue.extend({
     },
     searchUpdate(event: Event): void {
       if (event.target !== null && this.searching) {
+        this.current = 0;
         const target = event.target as HTMLInputElement;
         this.$emit('update:searchInput', target.value);
       } else {
@@ -290,10 +291,6 @@ export default Vue.extend({
   position: absolute;
   right: 7px;
   top: 6px;
-}
-
-.selected-name {
-  display: inline-block;
 }
 
 .search-results-container {

--- a/src/components/ProjectionSelect.vue
+++ b/src/components/ProjectionSelect.vue
@@ -16,7 +16,7 @@
       <div class="clear-button">
         <font-awesome-icon
           icon="times-circle"
-          :style="{visibility: hasSomeInput ? 'visible' : 'hidden'}"
+          :style="{visibility: selectedEpsgCode !== '' ? 'visible' : 'hidden'}"
           @click="clearProjection"
         />
       </div>

--- a/src/components/ProjectionSelect.vue
+++ b/src/components/ProjectionSelect.vue
@@ -1,6 +1,18 @@
 <template>
-  <div>
+  <div
+    v-on-clickaway="dismiss"
+  >
     <div class="container">
+      <input
+        class="search-input"
+        type="text"
+        :value.sync="searchInput"
+        @focusin="open=true"
+        @keydown.enter="enter"
+        @keydown.down="down"
+        @keydown.up="up"
+        @input="searchUpdate"
+      >
       <div class="search-button">
         <font-awesome-icon
           icon="search"
@@ -10,21 +22,19 @@
           style="display: none"
         />
       </div>
-      <input
-        class="search-input"
-        type="text"
-        value="EPSG:4326 - WGS 84"
-        @keydown.enter="enter"
-        @keydown.down="down"
-        @keydown.up="up"
-        @input="change"
-      >
     </div>
-    <div class="search-results-container">
+    <div
+      v-if="open"
+      class="search-results-container"
+    >
       <div class="search-results">
         <ul>
-          <li>
-            Hello World
+          <li
+            v-for="match in matches"
+            :key="match"
+            @click="enter"
+          >
+            {{ match }}
             <font-awesome-icon
               icon="info-circle"
             />
@@ -37,6 +47,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
+import { mixin as clickaway } from 'vue-clickaway';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faSearch, faTimesCircle, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -50,8 +61,13 @@ export default Vue.extend({
   components: {
     FontAwesomeIcon,
   },
+  mixins: [clickaway],
   props: {
-    selection: {
+    selected: {
+      type: String,
+      default: '',
+    },
+    searchInput: {
       type: String,
       default: '',
     },
@@ -61,22 +77,24 @@ export default Vue.extend({
       searching: false,
       open: false,
       current: 0,
-      suggestions: ['123', '4566'],
+      suggestions: ['123', '4566', 'abc', 'efg'],
     };
+  },
+  watch: {
+    searchInput(): void {
+      console.log('hey!');
+    },
   },
   computed: {
     matches(): string[] {
-      return this.suggestions.filter((str) => str.indexOf(this.selection) >= 0);
-    },
-    openSuggestion(): boolean {
-      return this.selection !== ''
-        && this.matches.length !== 0
-        && this.open === true;
+      return this.suggestions.filter((str) => str.indexOf(this.searchInput) >= 0);
     },
   },
   methods: {
+    dismiss(): void {
+      this.open = false;
+    },
     enter(): void {
-      // this.selection = this.matches[this.current];
       this.open = false;
     },
     up(): void {
@@ -100,8 +118,13 @@ export default Vue.extend({
     },
     // eslint-disable-next-line no-unused-vars
     suggestionClick(index: number): void {
-      // this.selection = this.matches[index];
       this.open = false;
+    },
+    searchUpdate(event: Event): void {
+      if (event.target !== null) {
+        const target = event.target as HTMLInputElement;
+        this.$emit('update:searchInput', target.value);
+      }
     },
   },
 });
@@ -113,12 +136,24 @@ export default Vue.extend({
   0 2px 2px 0 rgba(0, 0, 0, 0.14),
   0 1px 5px 0 rgba(0, 0, 0, 0.12);
   border-radius: 4px;
-  padding: 4px;
   background: #FFFFFF;
+  position: relative;
+  padding: 0;
+}
+
+.search-input {
+  width: 100%;
+  border-radius: 4px;
+  padding-left: calc(7px * 2 + 16px);
+  padding-top: 5px;
+  padding-bottom: 5px;
 }
 
 .search-button {
   display: inline-block;
+  position: absolute;
+  left: 7px;
+  top: 5px;
 }
 
 .selected-name {
@@ -140,13 +175,11 @@ export default Vue.extend({
   position: absolute;
   top: 5px;
   z-index: 10;
-  padding-top: 5px;
-  padding-bottom: 5px;
 }
 
 .search-results ul {
   list-style: none;
-  padding: 0;
+  padding: 4px 0;
 }
 
 .search-results ul li {
@@ -161,9 +194,25 @@ export default Vue.extend({
 .svg-inline--fa {
   width: 16px;
   height: 16px;
-  margin-left: 2px;
-  margin-right: 2px;
   opacity: 0.8;
+}
+
+@media (prefers-color-scheme: dark) {
+  .container {
+    background: #212121;
+  }
+
+  .search-results {
+    background: #212121;
+  }
+
+  .search-results ul li:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
+
+  .selected-flags-icon {
+    background: #FFF;
+  }
 }
 </style>
 

--- a/src/components/ProjectionSelect.vue
+++ b/src/components/ProjectionSelect.vue
@@ -43,11 +43,12 @@
           >
             <a
               target="_blank"
-              :href="`https://epsg.io/?q=${encodeURI(searchInput)}`">
+              :href="`https://epsg.io/?q=${encodeURI(searchInput)}`"
+            >
               <font-awesome-icon
                 icon="search"
               />
-              Search EPSG.io for '{{ searchInput }}'...
+              Search EPSG.io for '{{ searchInput }}' for better results...
             </a>
           </li>
         </ul>
@@ -253,19 +254,6 @@ export default Vue.extend({
         this.focusin();
       }
     },
-    isActive(index: number): boolean {
-      return index === this.current;
-    },
-    change(): void {
-      if (!this.searching) {
-        this.searching = true;
-        this.current = 0;
-      }
-    },
-    // eslint-disable-next-line no-unused-vars
-    suggestionClick(index: number): void {
-      this.searching = false;
-    },
     searchUpdate(event: Event): void {
       if (event.target !== null && this.searching) {
         const target = event.target as HTMLInputElement;
@@ -360,8 +348,8 @@ export default Vue.extend({
     background: #212121;
   }
 
-  .selected-flags-icon {
-    background: #FFF;
+  .search-result-list-item-selected {
+    background: rgba(255, 255, 255, 0.1);
   }
 }
 </style>

--- a/src/utils/epsgIndex.ts
+++ b/src/utils/epsgIndex.ts
@@ -1,0 +1,77 @@
+import allEpsgProjections from 'epsg-index/all.json';
+
+export interface Projection {
+  accuracy: number|null;
+  area: string|null;
+  bbox: number[]|null;
+  code: string;
+  kind: string;
+  name: string;
+  proj4: string|null;
+  unit: string|null;
+  wkt: string|null;
+}
+
+export default class EpsgIndex {
+  private readonly projectionsByCode: {[key: string]: Projection};
+
+  private readonly excludeProjectionsWithoutProj4: boolean;
+
+  constructor() {
+    this.excludeProjectionsWithoutProj4 = true;
+    this.projectionsByCode = allEpsgProjections as {[key: string]: Projection};
+  }
+
+  getProjectionByCode(code: string): Projection|null {
+    const projection = this.projectionsByCode[code];
+    if (projection === undefined) {
+      return null;
+    }
+    if (this.excludeProjectionsWithoutProj4 && projection.proj4 === null) {
+      return null;
+    }
+    return projection;
+  }
+
+  searchProjections(searchString: string, limit: number): Projection[] {
+    const matches: Projection[] = [];
+    const searchInputLower = searchString.toLowerCase();
+    const projections = Object.values(this.projectionsByCode);
+    for (let i = 0, len = projections.length; i < len; i += 1) {
+      if (matches.length >= limit) {
+        break;
+      }
+
+      const projection = projections[i];
+
+      if (
+        !(this.excludeProjectionsWithoutProj4 && projection.proj4 === null)
+        && EpsgIndex.projectionMatchesSearchTerm(projection, searchInputLower)) {
+        matches.push(projection);
+      }
+    }
+    return matches;
+  }
+
+  /**
+   * @param {Projection} projection
+   * @param {string} searchInput Must be a lowercase string
+   */
+  private static projectionMatchesSearchTerm(projection: Projection, searchInput: string): boolean {
+    // Does the search input contain the epsg code?
+    if (
+      projection.code.indexOf(searchInput) !== -1
+      || `epsg:${projection.code}`.indexOf(searchInput) !== -1
+    ) {
+      return true;
+    }
+
+    // Does the name contain the search input?
+    if (projection.name.toLowerCase().indexOf(searchInput) !== -1) {
+      return true;
+    }
+
+    // Does the area contain the search input?
+    return (projection.area !== null && projection.area.toLowerCase().indexOf(searchInput) !== -1);
+  }
+}

--- a/src/utils/geoJsonGenerator.ts
+++ b/src/utils/geoJsonGenerator.ts
@@ -61,13 +61,14 @@ export default class GeoJsonGenerator {
     projection: proj4.Converter,
   ): PointFeature[] {
     return parsedData.reduce((result: object[], rowGroup) => {
-      const coordinate = projection.inverse([
-        parseFloat(rowGroup[groupNumberLookupByType.longitude[0] + 1]),
-        parseFloat(rowGroup[groupNumberLookupByType.latitude[0] + 1]),
-      ]);
+      let coordinate = [
+        parseFloat(rowGroup[groupNumberLookupByType.x[0] + 1]),
+        parseFloat(rowGroup[groupNumberLookupByType.y[0] + 1]),
+      ];
       if (Number.isNaN(coordinate[0]) || Number.isNaN(coordinate[1])) {
         return result;
       }
+      coordinate = projection.inverse(coordinate);
       const properties: Properties = {};
       if (GeoJsonGenerator.hasTimeDefined(groupNumberLookupByType)) {
         properties.time = rowGroup[groupNumberLookupByType.time[0] + 1];
@@ -109,8 +110,8 @@ export default class GeoJsonGenerator {
   }
 
   private static hasCoordinatesDefined(matchGroupTypeLookup: NumericArrayObject): boolean {
-    return GeoJsonGenerator.objectHasProperty(matchGroupTypeLookup, 'longitude')
-      && GeoJsonGenerator.objectHasProperty(matchGroupTypeLookup, 'latitude');
+    return GeoJsonGenerator.objectHasProperty(matchGroupTypeLookup, 'x')
+      && GeoJsonGenerator.objectHasProperty(matchGroupTypeLookup, 'y');
   }
 
   private static hasTimeDefined(matchGroupTypeLookup: NumericArrayObject): boolean {

--- a/src/utils/geoJsonGenerator.ts
+++ b/src/utils/geoJsonGenerator.ts
@@ -1,3 +1,4 @@
+import proj4 from 'proj4';
 import GroupSettings from '@/utils/groupSettings';
 
 type NumericArrayObject = { [key: string]: number[] };
@@ -21,7 +22,11 @@ interface PointFeature {
 }
 
 export default class GeoJsonGenerator {
-  static generate(parsedData: string[][], allGroupSettings: GroupSettings[]): string {
+  static generate(
+    parsedData: string[][],
+    allGroupSettings: GroupSettings[],
+    projection: proj4.Converter,
+  ): string {
     const groupNumberLookupByType = GeoJsonGenerator.getGroupNumberLookupByType(allGroupSettings);
     const output = GeoJsonGenerator.generateFeatureCollection();
 
@@ -33,7 +38,11 @@ export default class GeoJsonGenerator {
       // Todo: Add linestring feature
     }
 
-    const points = GeoJsonGenerator.generatePointFeatures(parsedData, groupNumberLookupByType);
+    const points = GeoJsonGenerator.generatePointFeatures(
+      parsedData,
+      groupNumberLookupByType,
+      projection,
+    );
     output.features.push(...points);
 
     return JSON.stringify(output, null, 2);
@@ -49,12 +58,13 @@ export default class GeoJsonGenerator {
   private static generatePointFeatures(
     parsedData: string[][],
     groupNumberLookupByType: NumericArrayObject,
+    projection: proj4.Converter,
   ): PointFeature[] {
     return parsedData.reduce((result: object[], rowGroup) => {
-      const coordinate = [
+      const coordinate = projection.inverse([
         parseFloat(rowGroup[groupNumberLookupByType.longitude[0] + 1]),
         parseFloat(rowGroup[groupNumberLookupByType.latitude[0] + 1]),
-      ];
+      ]);
       if (Number.isNaN(coordinate[0]) || Number.isNaN(coordinate[1])) {
         return result;
       }

--- a/tests/unit/utils/epsgIndex.spec.ts
+++ b/tests/unit/utils/epsgIndex.spec.ts
@@ -1,0 +1,61 @@
+import EpsgIndex from '@/utils/epsgIndex';
+
+describe('EpsgIndex', () => {
+  describe('getProjectionByCode', () => {
+    it('Returns projection for code', () => {
+      const epsgIndex = new EpsgIndex();
+      const wgs84Projection = epsgIndex.getProjectionByCode('4326');
+      if (wgs84Projection === null) {
+        throw Error('');
+      }
+      expect(wgs84Projection.name).toEqual('WGS 84');
+    });
+
+    it('Returns null for unknown code', () => {
+      const epsgIndex = new EpsgIndex();
+      const unknownProjection = epsgIndex.getProjectionByCode('999999');
+      expect(unknownProjection).toBeNull();
+    });
+
+    it('Returns null for projection with null proj4', () => {
+      const epsgIndex = new EpsgIndex();
+      const unknownProjection = epsgIndex.getProjectionByCode('2963');
+      expect(unknownProjection).toBeNull();
+    });
+  });
+
+  describe('searchProjections', () => {
+    it('Returns projections with code', () => {
+      const epsgIndex = new EpsgIndex();
+      const projections = epsgIndex.searchProjections('4326', 10);
+      expect(projections).toHaveLength(1);
+      expect(projections[0].code).toEqual('4326');
+      expect(projections[0].name).toEqual('WGS 84');
+    });
+    it('Returns projections with code with EPSG prefix', () => {
+      const epsgIndex = new EpsgIndex();
+      const projections = epsgIndex.searchProjections('EPSG:4326', 10);
+      expect(projections).toHaveLength(1);
+      expect(projections[0].code).toEqual('4326');
+      expect(projections[0].name).toEqual('WGS 84');
+    });
+    it('Returns projections with name', () => {
+      const epsgIndex = new EpsgIndex();
+      const projections = epsgIndex.searchProjections('British National', 10);
+      expect(projections).toHaveLength(2);
+      expect(projections[1].code).toEqual('27700');
+    });
+    it('Returns projections with area', () => {
+      const epsgIndex = new EpsgIndex();
+      const projections = epsgIndex.searchProjections('North Sea', 10);
+      expect(projections).toHaveLength(7);
+      expect(projections[6].code).toEqual('32631');
+    });
+    it('Returns projections with limit', () => {
+      const epsgIndex = new EpsgIndex();
+      const projections = epsgIndex.searchProjections('British National', 1);
+      expect(projections).toHaveLength(1);
+      expect(projections[0].code).toEqual('7405');
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "importHelpers": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,


### PR DESCRIPTION
This PR addresses this issue: #30 

The goal is to add an input field which allows someone to input a name or EPSG code to select a map projection. This projection would be used to project the input data coordinates into the standard WGS84 projection. For convenience, the map projection will default to WGS84.

For now, there is no intention to support custom projections.