### PR TITLE
Add Download and Copy-to-Clipboard button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3621,6 +3621,12 @@
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
     },
+    "@types/file-saver": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.1.tgz",
+      "integrity": "sha512-g1QUuhYVVAamfCifK7oB7G3aIl4BbOyzDOqVyUfEr4tfBKrXfeH+M+Tg7HKCXSrbzxYdhyCP7z9WbKo0R2hBCw==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
@@ -10284,6 +10290,11 @@
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.5.0"
       }
+    },
+    "file-saver": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8200,6 +8200,14 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-to-clipboard": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.1.tgz",
+      "integrity": "sha512-btru1Q6RD9wbonIvEU5EfnhIRGHLo//BGXQ1hNAD2avIs/nBZlpbOeKtv3mhoUByN4DB9Cb6/vXBymj1S43KmA==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "copy-webpack-plugin": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
@@ -19994,6 +20002,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/vue-fontawesome": "^0.1.9",
     "@types/codemirror": "0.0.85",
     "codemirror": "^5.51.0",
+    "copy-to-clipboard": "^3.2.1",
     "core-js": "^3.6.4",
     "debounce": "^1.2.0",
     "epsg-index": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "core-js": "^3.6.4",
     "debounce": "^1.2.0",
     "epsg-index": "^1.0.0",
+    "file-saver": "^2.0.2",
     "proj4": "^2.6.0",
     "regexp": "^1.0.0",
     "v-click-outside": "^3.0.1",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@types/debounce": "^1.2.0",
+    "@types/file-saver": "^2.0.1",
     "@types/jest": "^25.1.2",
     "@types/proj4": "^2.5.0",
     "@typescript-eslint/eslint-plugin": "^2.19.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -270,4 +270,10 @@ h2 {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
+
+@media (prefers-color-scheme: dark) {
+  .v-content {
+    background-color: #121212;
+  }
+}
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -257,6 +257,10 @@ h2 {
   margin-bottom: 10px;
 }
 
+.v-content {
+  background-color: #F6F6F6;
+}
+
 .horizontally-scroll-container {
   display: block;
   width: 100%;

--- a/src/App.vue
+++ b/src/App.vue
@@ -110,6 +110,7 @@
             </a>
           </p>
           <DownloadOutputButton :value="geoJson" />
+          <CopyOutputButton :value="geoJson" />
           <GeoJsonOutput :value="geoJson" />
         </v-flex>
       </v-container>
@@ -134,6 +135,7 @@ import GroupSettings from '@/utils/groupSettings';
 import RegExpFlagsConfig from '@/utils/regExpFlagsConfig';
 import regExpFlagsFormatter from '@/utils/regExpFlagsFormatter';
 import DownloadOutputButton from '@/components/DownloadOutputButton.vue';
+import CopyOutputButton from '@/components/CopyOutputButton.vue';
 
 library.add(faExternalLinkAlt);
 
@@ -146,6 +148,7 @@ export default Vue.extend({
     ProjectionSelect,
     GroupSettingsTable,
     DownloadOutputButton,
+    CopyOutputButton,
     GeoJsonOutput,
     FontAwesomeIcon,
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -109,6 +109,7 @@
               <font-awesome-icon icon="external-link-alt" />
             </a>
           </p>
+          <DownloadOutputButton :value="geoJson" />
           <GeoJsonOutput :value="geoJson" />
         </v-flex>
       </v-container>
@@ -132,6 +133,7 @@ import GeoJsonGenerator from '@/utils/geoJsonGenerator';
 import GroupSettings from '@/utils/groupSettings';
 import RegExpFlagsConfig from '@/utils/regExpFlagsConfig';
 import regExpFlagsFormatter from '@/utils/regExpFlagsFormatter';
+import DownloadOutputButton from '@/components/DownloadOutputButton.vue';
 
 library.add(faExternalLinkAlt);
 
@@ -143,6 +145,7 @@ export default Vue.extend({
     DataInput,
     ProjectionSelect,
     GroupSettingsTable,
+    DownloadOutputButton,
     GeoJsonOutput,
     FontAwesomeIcon,
   },

--- a/src/components/CopyOutputButton.vue
+++ b/src/components/CopyOutputButton.vue
@@ -1,0 +1,108 @@
+<template>
+  <span>
+    <button
+      class="copy-output-button"
+      @click="copyToClipboard"
+    >
+      <font-awesome-icon
+        :icon="icon"
+      />
+      <span class="copy-output-button-label">{{ labelText }}</span>
+    </button>
+  </span>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faCopy, faCheck, faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import copy from 'copy-to-clipboard';
+
+library.add(faCopy);
+library.add(faCheck);
+library.add(faExclamationCircle);
+
+export default Vue.extend({
+  name: 'CopyOutputButton',
+  components: {
+    FontAwesomeIcon,
+  },
+  props: {
+    value: {
+      type: String,
+      default: '',
+    },
+  },
+  data: () => ({
+    icon: 'copy',
+    labelText: 'Copy to clipboard',
+  }),
+  mounted(): void {
+    const labels = this.$el.getElementsByClassName('copy-output-button-label');
+    const label = labels.item(0) as HTMLSpanElement;
+    // Add +1 to work around glitchy text resizing when changing the label.
+    label.style.width = `${label.offsetWidth + 1}px`;
+  },
+  methods: {
+    copyToClipboard(): void {
+      try {
+        const success = copy(this.value);
+        if (success) {
+          this.icon = 'check';
+          this.labelText = 'Copied!';
+        } else {
+          this.displayError();
+        }
+      } catch (e) {
+        this.displayError();
+      }
+      setTimeout(() => {
+        this.icon = 'copy';
+        this.labelText = 'Copy to clipboard';
+      }, 2 * 1000);
+    },
+    displayError(): void {
+      this.icon = 'exclamation-circle';
+      this.labelText = 'Failed to copy';
+    },
+  },
+});
+</script>
+
+<style scoped>
+button {
+  background-color: #FFF;
+  border-radius: 4px;
+  padding: 5px 15px;
+  margin: 10px 10px 10px 0;
+  box-shadow:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+}
+
+.copy-output-button-label {
+  display: inline-block;
+  box-sizing: content-box;
+  padding: 0;
+  margin: 0;
+  border: none;
+}
+
+.copy-output-button-success {
+
+}
+
+.svg-inline--fa {
+  width: 16px;
+  height: 16px;
+  margin-right: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+  button {
+    background-color: #242424;
+  }
+}
+</style>

--- a/src/components/DownloadOutputButton.vue
+++ b/src/components/DownloadOutputButton.vue
@@ -1,0 +1,64 @@
+<template>
+  <span>
+    <button
+      @click="download"
+    >
+      <font-awesome-icon
+        icon="file-download"
+      />
+      Download GeoJSON
+    </button>
+  </span>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faFileDownload } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import FileSaver from 'file-saver';
+
+library.add(faFileDownload);
+
+export default Vue.extend({
+  name: 'DownloadOutputButton',
+  components: {
+    FontAwesomeIcon,
+  },
+  props: {
+    value: {
+      type: String,
+      default: '',
+    },
+  },
+  methods: {
+    download(): void {
+      const blob = new Blob([this.value], { type: 'text/plain;charset=utf-8' });
+      FileSaver.saveAs(blob, 'file.geojson');
+    },
+  },
+});
+</script>
+
+<style scoped>
+button {
+  background-color: #FFF;
+  border-radius: 4px;
+  padding: 5px 15px;
+  margin: 10px 10px 10px 0;
+  box-shadow:
+    0 3px 1px -2px rgba(0, 0, 0, 0.2),
+    0 2px 2px 0 rgba(0, 0, 0, 0.14),
+    0 1px 5px 0 rgba(0, 0, 0, 0.12);
+}
+
+.svg-inline--fa {
+  margin-right: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+  button {
+    background-color: #242424;
+  }
+}
+</style>

--- a/tests/unit/components/copyOutputButton.spec.ts
+++ b/tests/unit/components/copyOutputButton.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { mount, Wrapper } from '@vue/test-utils';
 import CopyOutputButton from '@/components/CopyOutputButton.vue';
 
@@ -27,8 +28,10 @@ describe('CopyOutputButton', () => {
   });
 
   test('copies to clipboard', async () => {
+    console.error = jest.fn();
     wrapper.find('.copy-output-button').trigger('click');
     await wrapper.vm.$nextTick();
+    expect(console.error).toHaveBeenCalled();
     expect(getLabel(wrapper).textContent).toEqual('Failed to copy');
     await new Promise((resolve) => setTimeout(() => {
       expect(getLabel(wrapper).textContent).toEqual('Copy to clipboard');

--- a/tests/unit/components/copyOutputButton.spec.ts
+++ b/tests/unit/components/copyOutputButton.spec.ts
@@ -1,0 +1,42 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import CopyOutputButton from '@/components/CopyOutputButton.vue';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getLabel(wrapper: Wrapper<any>): HTMLSpanElement {
+  const labels = wrapper.element.getElementsByClassName('copy-output-button-label');
+  return labels.item(0) as HTMLSpanElement;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: Wrapper<any>;
+
+describe('CopyOutputButton', () => {
+  beforeAll(() => {
+    wrapper = mount(CopyOutputButton, {
+      propsData: {
+        value: 'hello world',
+      },
+    });
+  });
+
+  test('mounts correctly and sets width', async () => {
+    await wrapper.vm.$nextTick();
+    const label = getLabel(wrapper);
+    expect(label.style.width).toMatch(/[0-9]+px/);
+    expect(label.textContent).toEqual('Copy to clipboard');
+  });
+
+  test('copies to clipboard', async () => {
+    wrapper.find('.copy-output-button').trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(getLabel(wrapper).textContent).toEqual('Failed to copy');
+    await new Promise((resolve) => setTimeout(() => {
+      expect(getLabel(wrapper).textContent).toEqual('Copy to clipboard');
+      resolve();
+    }, 2500));
+  });
+
+  afterAll(() => {
+    wrapper.destroy();
+  });
+});

--- a/tests/unit/components/downloadOutputButton.spec.ts
+++ b/tests/unit/components/downloadOutputButton.spec.ts
@@ -1,0 +1,23 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import DownloadOutputButton from '@/components/DownloadOutputButton.vue';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let wrapper: Wrapper<any>;
+
+describe('CopyOutputButton', () => {
+  beforeAll(() => {
+    wrapper = mount(DownloadOutputButton, {
+      propsData: {
+        value: 'hello world',
+      },
+    });
+  });
+
+  test('mounts with no errors', async () => {
+    await wrapper.vm.$nextTick();
+  });
+
+  afterAll(() => {
+    wrapper.destroy();
+  });
+});

--- a/tests/unit/components/matchGroupTypeSelect.spec.ts
+++ b/tests/unit/components/matchGroupTypeSelect.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { mount, Wrapper } from '@vue/test-utils';
 import MatchGroupTypeSelect from '@/components/MatchGroupTypeSelect.vue';
 
@@ -54,11 +55,14 @@ describe('MatchGroupTypeSelect', () => {
   });
 
   test('Focus changes displayed value in input field', async () => {
+    // The following console error would normally be reported in the logs:
+    // "[Vue warn]: Error in nextTick: "TypeError: document.createRange is not a function""
+    // This is because of how vue-test-utils mocks the document.
+    // Since we've mocked it in this test, the error should not appear in the logs.
+    console.error = jest.fn();
     wrapper.find('.search-input').trigger('focusin');
-    // A console error: "[Vue warn]: Error in nextTick: "Error: Range is mocked""
-    // will be reported in the logs... which can be ignored, because the document
-    // is only partially implemented by vue-test-utils.
     await wrapper.vm.$nextTick();
+    expect(console.error).toHaveBeenCalled();
     expect(getInputField(wrapper).value).toEqual('My "Custom" Name');
   });
 


### PR DESCRIPTION
These buttons make the act of viewing the GeoJSON in another app easier. They haven't been fully tested on platforms other than Chrome and Safari.

<img width="532" alt="Screenshot 2020-02-17 at 23 34 20" src="https://user-images.githubusercontent.com/3501061/74692228-2eeb8d00-51de-11ea-9997-96ce99e67c1d.png">

This PR also changes the background colour of the page from white to a slight grey for the "light" colour-scheme.

Finally, some of the test have been changed to mock the console object, to stop errors appearing when running `npm run test`. The logs originate from Vue, which is why they are out of our control. The tests assert that the error has be logged.