### PR TITLE
Output Settings UI Tweak

### DIFF
--- a/src/components/FeatureTypeGraphic.vue
+++ b/src/components/FeatureTypeGraphic.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <svg
-      viewBox="0 0 51 55"
+      viewBox="0 0 51 40"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
       xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -94,14 +94,6 @@
           </g>
         </g>
       </g>
-      <text
-        x="50%"
-        y="95%"
-        text-anchor="middle"
-        style="font-size: 10px"
-      >
-        {{ featureLabel }}
-      </text>
     </svg>
     {{ featureLabel }}
   </div>
@@ -138,6 +130,10 @@ export default Vue.extend({
 </script>
 
 <style scoped>
+svg {
+  max-width: 100px;
+}
+
 .linestring {
   stroke: #000000;
 }

--- a/src/components/FeatureTypeGraphic.vue
+++ b/src/components/FeatureTypeGraphic.vue
@@ -1,9 +1,7 @@
 <template>
   <div>
     <svg
-      width="100px"
-      height="70px"
-      viewBox="0 0 51 34"
+      viewBox="0 0 51 55"
       version="1.1"
       xmlns="http://www.w3.org/2000/svg"
       xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -96,7 +94,16 @@
           </g>
         </g>
       </g>
+      <text
+        x="50%"
+        y="95%"
+        text-anchor="middle"
+        style="font-size: 10px"
+      >
+        {{ featureLabel }}
+      </text>
     </svg>
+    {{ featureLabel }}
   </div>
 </template>
 
@@ -113,6 +120,10 @@ export default Vue.extend({
     featureType: {
       type: String,
       default: 'both',
+    },
+    featureLabel: {
+      type: String,
+      default: 'Both',
     },
   },
   computed: {

--- a/src/components/OutputSettings.vue
+++ b/src/components/OutputSettings.vue
@@ -10,9 +10,9 @@
       <label for="points">
         <FeatureTypeGraphic
           feature-type="points"
+          feature-label="Points"
           :selected="mountedFeatureType==='points'"
         />
-        Points
       </label>
       <input
         id="both"
@@ -23,9 +23,9 @@
       <label for="both">
         <FeatureTypeGraphic
           feature-type="both"
+          feature-label="Both"
           :selected="mountedFeatureType==='both'"
         />
-        Both
       </label>
       <input
         id="linestring"
@@ -36,9 +36,9 @@
       <label for="linestring">
         <FeatureTypeGraphic
           feature-type="linestring"
+          feature-label="Linestring"
           :selected="mountedFeatureType==='linestring'"
         />
-        Linestring
       </label>
     </div>
     <div
@@ -184,7 +184,8 @@ export default Vue.extend({
 <style scoped>
 .feature-type {
   width: 100%;
-  display: flex;
+  max-width: 400px;
+  display: inline-flex;
   flex-direction: row;
   background: #FFF;
   box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
@@ -193,11 +194,12 @@ export default Vue.extend({
   border-radius: 4px;
   margin: 5px 0;
 }
+
 .feature-type label {
   cursor: pointer;
   text-align: center;
-  flex-grow: 1;
-  padding: 10px;
+  padding: 10px 15px;
+  width: 100%;
 }
 
 .feature-type input:checked + label {

--- a/src/components/OutputSettings.vue
+++ b/src/components/OutputSettings.vue
@@ -184,7 +184,8 @@ export default Vue.extend({
 <style scoped>
 .feature-type {
   width: 100%;
-  max-width: 400px;
+  max-width: calc(150px * 3);
+  overflow-x: scroll;
   display: inline-flex;
   flex-direction: row;
   background: #FFF;
@@ -196,10 +197,13 @@ export default Vue.extend({
 }
 
 .feature-type label {
+  display: inline-block;
   cursor: pointer;
   text-align: center;
   padding: 10px 15px;
   width: 100%;
+  min-width: 107px;
+  max-width: 150px;
 }
 
 .feature-type input:checked + label {


### PR DESCRIPTION
Resolves #50.

This was done by making the Feature type selection scrollable when the width it too small, and by setting a max-width.

Small screens:

<img width="437" alt="Screenshot 2020-02-28 at 20 25 14" src="https://user-images.githubusercontent.com/3501061/75585234-7fc67580-5a69-11ea-8431-b055d633a014.png">

Wide screens:

<img width="429" alt="Screenshot 2020-02-28 at 20 32 20" src="https://user-images.githubusercontent.com/3501061/75585245-83f29300-5a69-11ea-8124-781fc70dd66a.png">
