### PR TITLE
NPM Update + Vue fixes + Other small changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2996,24 +2996,24 @@
       }
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "0.2.30",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.30.tgz",
-      "integrity": "sha512-TsRwpTuKwFNiPhk1UfKgw7zNPeV5RhNp2Uw3pws+9gDAkPGKrtjR1y2lI3SYn7+YzyfuNknflpBA1LRKjt7hMg=="
+      "version": "0.2.31",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.31.tgz",
+      "integrity": "sha512-xfnPyH6NN5r/h1/qDYoGB0BlHSID902UkQzxR8QsoKDh55KAPr8ruAoie12WQEEQT8lRE2wtV7LoUllJ1HqCag=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "1.2.30",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.30.tgz",
-      "integrity": "sha512-E3sAXATKCSVnT17HYmZjjbcmwihrNOCkoU7dVMlasrcwiJAHxSKeZ+4WN5O+ElgO/FaYgJmASl8p9N7/B/RttA==",
+      "version": "1.2.31",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.31.tgz",
+      "integrity": "sha512-lqUWRK+ylHQJG5Kiez4XrAZAfc7snxCc+X59quL3xPfMnxzfyf1lt+/hD7X1ZL4KlzAH2KFzMuEVrolo/rAkog==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.30"
+        "@fortawesome/fontawesome-common-types": "^0.2.31"
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.14.0.tgz",
-      "integrity": "sha512-M933RDM8cecaKMWDSk3FRYdnzWGW7kBBlGNGfvqLVwcwhUPNj9gcw+xZMrqBdRqxnSXdl3zWzTCNNGEtFUq67Q==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.0.tgz",
+      "integrity": "sha512-4dGRsOnGBPM7c0fd3LuiU6LgRSLn01rw1LJ370yC2iFMLUcLCLLynZhQbMhsiJmMwQM/YmPQblAdyHKVCgsIAA==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "^0.2.30"
+        "@fortawesome/fontawesome-common-types": "^0.2.31"
       }
     },
     "@fortawesome/vue-fontawesome": {
@@ -4542,13 +4542,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.2.0.tgz",
-      "integrity": "sha512-zBNRkzvLSwo6y5TG0DVcmshZIYBHKtmzD4N+LYnfTFpzc4bc79o8jNRSb728WV7A4Cegbs+MV5IRAj8BKBgOVQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.3.0.tgz",
+      "integrity": "sha512-RqEcaHuEKnn3oPFislZ6TNzsBLqpZjN93G69SS+laav/I8w/iGMuMq97P0D2/2/kW4SCebHggqhbcCfbDaaX+g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.2.0",
-        "@typescript-eslint/scope-manager": "4.2.0",
+        "@typescript-eslint/experimental-utils": "4.3.0",
+        "@typescript-eslint/scope-manager": "4.3.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -4557,55 +4557,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.2.0.tgz",
-      "integrity": "sha512-5BBj6BjgHEndBaQQpUVzRIPERz03LBc0MCQkHwUaH044FJFL08SwWv/sQftk7gf0ShZ2xZysz0LTwCwNt4Xu3w==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.3.0.tgz",
+      "integrity": "sha512-cmmIK8shn3mxmhpKfzMMywqiEheyfXLV/+yPDnOTvQX/ztngx7Lg/OD26J8gTZfkLKUmaEBxO2jYP3keV7h2OQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.2.0",
-        "@typescript-eslint/types": "4.2.0",
-        "@typescript-eslint/typescript-estree": "4.2.0",
+        "@typescript-eslint/scope-manager": "4.3.0",
+        "@typescript-eslint/types": "4.3.0",
+        "@typescript-eslint/typescript-estree": "4.3.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.2.0.tgz",
-      "integrity": "sha512-54jJ6MwkOtowpE48C0QJF9iTz2/NZxfKVJzv1ha5imigzHbNSLN9yvbxFFH1KdlRPQrlR8qxqyOvLHHxd397VA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.3.0.tgz",
+      "integrity": "sha512-JyfRnd72qRuUwItDZ00JNowsSlpQGeKfl9jxwO0FHK1qQ7FbYdoy5S7P+5wh1ISkT2QyAvr2pc9dAemDxzt75g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.2.0",
-        "@typescript-eslint/types": "4.2.0",
-        "@typescript-eslint/typescript-estree": "4.2.0",
+        "@typescript-eslint/scope-manager": "4.3.0",
+        "@typescript-eslint/types": "4.3.0",
+        "@typescript-eslint/typescript-estree": "4.3.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.2.0.tgz",
-      "integrity": "sha512-Tb402cxxObSxWIVT+PnBp5ruT2V/36yj6gG4C9AjkgRlZpxrLAzWDk3neen6ToMBGeGdxtnfFLoJRUecGz9mYQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.3.0.tgz",
+      "integrity": "sha512-cTeyP5SCNE8QBRfc+Lgh4Xpzje46kNUhXYfc3pQWmJif92sjrFuHT9hH4rtOkDTo/si9Klw53yIr+djqGZS1ig==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.2.0",
-        "@typescript-eslint/visitor-keys": "4.2.0"
+        "@typescript-eslint/types": "4.3.0",
+        "@typescript-eslint/visitor-keys": "4.3.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-xkv5nIsxfI/Di9eVwN+G9reWl7Me9R5jpzmZUch58uQ7g0/hHVuGUbbn4NcxcM5y/R4wuJIIEPKPDb5l4Fdmwg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.3.0.tgz",
+      "integrity": "sha512-Cx9TpRvlRjOppGsU6Y6KcJnUDOelja2NNCX6AZwtVHRzaJkdytJWMuYiqi8mS35MRNA3cJSwDzXePfmhU6TANw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.2.0.tgz",
-      "integrity": "sha512-iWDLCB7z4MGkLipduF6EOotdHNtgxuNKnYD54nMS/oitFnsk4S3S/TE/UYXQTra550lHtlv9eGmp+dvN9pUDtA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.3.0.tgz",
+      "integrity": "sha512-ZAI7xjkl+oFdLV/COEz2tAbQbR3XfgqHEGy0rlUXzfGQic6EBCR4s2+WS3cmTPG69aaZckEucBoTxW9PhzHxxw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.2.0",
-        "@typescript-eslint/visitor-keys": "4.2.0",
+        "@typescript-eslint/types": "4.3.0",
+        "@typescript-eslint/visitor-keys": "4.3.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -4615,12 +4615,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-WIf4BNOlFOH2W+YqGWa6YKLcK/EB3gEj2apCrqLw6mme1RzBy0jtJ9ewJgnrZDB640zfnv8L+/gwGH5sYp/rGw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.3.0.tgz",
+      "integrity": "sha512-xZxkuR7XLM6RhvLkgv9yYlTcBHnTULzfnw4i6+z2TGBLy9yljAypQaZl9c3zFvy7PNI7fYWyvKYtohyF8au3cw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.2.0",
+        "@typescript-eslint/types": "4.3.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "dependencies": {
@@ -10128,22 +10128,15 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
-      "integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-7.0.0.tgz",
+      "integrity": "sha512-SFcM8ZMdVRUQKrAryl6Q5razrJtloATUOKTZoK/8yvQig1c1L3VRoMLL9AXiV3VNsKXolkk6yeMIiqGf33/Iew==",
       "dev": true,
       "requires": {
+        "eslint-utils": "^2.1.0",
         "natural-compare": "^1.4.0",
-        "semver": "^5.6.0",
-        "vue-eslint-parser": "^7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
+        "semver": "^7.3.2",
+        "vue-eslint-parser": "^7.1.0"
       }
     },
     "eslint-scope": {
@@ -20612,9 +20605,9 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.0.tgz",
-      "integrity": "sha512-ofBzoCqf6Nv/PoWb/ByV3VNKy2KJSikamOBxvR3E6eVdIw10GwAXoyvMWXXjZJK2s6S27ZE8fI+JBTnGaovl6Q==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.1.tgz",
+      "integrity": "sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==",
       "dev": true,
       "requires": {
         "@types/jest": "26.x",
@@ -20741,9 +20734,9 @@
           }
         },
         "yargs-parser": {
-          "version": "20.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.1.0.tgz",
-          "integrity": "sha512-RV4YEjMLfjWkK9jNV/aZytlJ5uz+JBk7t29FofILa41jJAU/yCwghgsjH2xT0h7eu7b6MrCDJb1qZjeDJ/jI1w==",
+          "version": "20.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
+          "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
           "dev": true
         }
       }
@@ -21590,9 +21583,9 @@
       }
     },
     "vue-property-decorator": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-9.0.0.tgz",
-      "integrity": "sha512-oegTNPItuHOkW0AP1MnbdNwkmyhfsUIIXvIRHpgC18tVoEo21/i6kItyeekjMs8JgZJeuHzsaTc/DZaJFH4IWQ=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-9.0.2.tgz",
+      "integrity": "sha512-mxuJHfUGs/3rUyFj2vykDIvYXCUKBrzhemm7mT8dE9QYTbNA/4qVQ5gwhNCIkKyQc8RQIXQ+0jriqinUDuuU9w=="
     },
     "vue-style-loader": {
       "version": "4.1.2",
@@ -21629,9 +21622,9 @@
       "dev": true
     },
     "vuetify": {
-      "version": "2.3.10",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.3.10.tgz",
-      "integrity": "sha512-KzL/MhZ7ajubm9kwbdCoA/cRV50RX+a5Hcqiwt7Am1Fni2crDtl2no05UNwKroTfscrYYf07gq3WIFSurPsnCA=="
+      "version": "2.3.12",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.3.12.tgz",
+      "integrity": "sha512-FSt1pzpf0/Lh0xuctAPB7RiLbUl7bzVc7ejbXLLhfmgm7zD7yabuhVYuyVda/SzokjZMGS3j1lNu2lLfdrz0oQ=="
     },
     "vuetify-loader": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test": "vue-cli-service test:unit"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^1.2.30",
-    "@fortawesome/free-solid-svg-icons": "^5.14.0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.31",
+    "@fortawesome/free-solid-svg-icons": "^5.15.0",
     "@fortawesome/vue-fontawesome": "^2.0.0",
     "codemirror": "^5.58.1",
     "copy-to-clipboard": "^3.3.1",
@@ -25,8 +25,8 @@
     "vue": "^2.6.12",
     "vue-class-component": "^7.2.6",
     "vue-popperjs": "^2.3.0",
-    "vue-property-decorator": "^9.0.0",
-    "vuetify": "^2.3.10"
+    "vue-property-decorator": "^9.0.2",
+    "vuetify": "^2.3.12"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",
@@ -35,8 +35,8 @@
     "@types/file-saver": "^2.0.1",
     "@types/jest": "^26.0.14",
     "@types/proj4": "^2.5.0",
-    "@typescript-eslint/eslint-plugin": "^4.2.0",
-    "@typescript-eslint/parser": "^4.2.0",
+    "@typescript-eslint/eslint-plugin": "^4.3.0",
+    "@typescript-eslint/parser": "^4.3.0",
     "@vue/cli-plugin-babel": "^4.5.6",
     "@vue/cli-plugin-eslint": "^4.5.6",
     "@vue/cli-plugin-typescript": "^4.5.6",
@@ -48,11 +48,11 @@
     "babel-eslint": "^10.1.0",
     "codecov": "^3.7.2",
     "eslint": "^7.10.0",
-    "eslint-plugin-vue": "^6.2.2",
+    "eslint-plugin-vue": "^7.0.0",
     "jest": "^26.4.2",
     "sass": "^1.26.11",
     "sass-loader": "^10.0.2",
-    "ts-jest": "^26.4.0",
+    "ts-jest": "^26.4.1",
     "typescript": "^4.0.3",
     "vue-cli-plugin-vuetify": "^2.0.7",
     "vue-template-compiler": "^2.6.12",

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,7 +24,7 @@
       </v-btn>
     </v-app-bar>
 
-    <v-content>
+    <v-main>
       <v-container>
         <v-flex xs12>
           <p class="subtitle-1">
@@ -125,7 +125,7 @@
           <GeoJsonOutput :value="geoJson" />
         </v-flex>
       </v-container>
-    </v-content>
+    </v-main>
   </v-app>
 </template>
 

--- a/src/components/GroupSettingsTable.vue
+++ b/src/components/GroupSettingsTable.vue
@@ -154,13 +154,23 @@ export default Vue.extend({
     },
     items: {
       handler(updatedItems: Item[]): void {
+        let modified = false;
+        // Clone the groupSettings so we can make changes to it.
+        const newAllGroupSettings = this.allGroupSettings.map((a) => ({ ...a }));
         updatedItems.forEach((updatedItem, index) => {
-          if (this.allGroupSettings.length < 0) {
-            this.allGroupSettings.push(updatedItem.groupSettings);
-          } else {
-            this.allGroupSettings[index] = updatedItem.groupSettings;
+          if (newAllGroupSettings.length < updatedItems.length) {
+            newAllGroupSettings.push(updatedItem.groupSettings);
+            modified = true;
+          } else if (
+            JSON.stringify(newAllGroupSettings[index]) !== JSON.stringify(updatedItem.groupSettings)
+          ) {
+            newAllGroupSettings[index] = updatedItem.groupSettings;
+            modified = true;
           }
         });
+        if (modified) {
+          this.$emit('update:allGroupSettings', newAllGroupSettings);
+        }
       },
       deep: true,
     },

--- a/src/components/RegexFlags.vue
+++ b/src/components/RegexFlags.vue
@@ -100,9 +100,11 @@ export default Vue.extend({
     },
     flagOptionItems: {
       handler(): void {
+        const newFlags = JSON.parse(JSON.stringify(this.flags));
         this.flagOptionItems.forEach(({ key, selected }) => {
-          this.flags[key] = selected;
+          newFlags[key] = selected;
         });
+        this.$emit('update:flags', newFlags);
       },
       deep: true,
     },
@@ -113,7 +115,7 @@ export default Vue.extend({
   methods: {
     setFlags(): void {
       this.flagOptionItems.forEach(({ key }, i) => {
-        this.flagOptionItems[i].selected = this.flags[key];
+        this.flagOptionItems[i].selected = this.flags[key] ?? false;
       });
     },
     dismiss(): void {

--- a/src/components/RegexInput.vue
+++ b/src/components/RegexInput.vue
@@ -14,7 +14,7 @@
       </div>
       <regex-flags
         class="regex-flags"
-        :flags.sync="flags"
+        :flags.sync="selectedFlags"
       />
     </div>
     <div
@@ -59,6 +59,7 @@ export default Vue.extend({
     },
   },
   data: () => ({
+    selectedFlags: {} as RegExpFlagsConfig,
     errorMessage: 'Hello!',
     valueWatchEventHandler: (): void => {
       // do nothing.
@@ -69,6 +70,9 @@ export default Vue.extend({
   watch: {
     value(): void {
       this.valueWatchEventHandler();
+    },
+    selectedFlags(): void {
+      this.$emit('update:flags', this.selectedFlags);
     },
   },
   mounted() {
@@ -96,6 +100,8 @@ export default Vue.extend({
       this.valueWatchEventHandler = debounce(() => {
         this.update();
       }, 100);
+
+      this.selectedFlags = { ...this.flags };
     },
     initializeChangeEventHandler(): void {
       if (this.codeMirror === null) {

--- a/src/utils/parser.ts
+++ b/src/utils/parser.ts
@@ -24,6 +24,13 @@ export default class Parser {
       return allMatches;
     }
 
-    return Array.from(data.matchAll(this.regex));
+    if (this.regex.global) {
+      return Array.from(data.matchAll(this.regex));
+    }
+    const singleMatch = data.match(this.regex);
+    if (singleMatch) {
+      return [singleMatch];
+    }
+    return [];
   }
 }


### PR DESCRIPTION
This PR includes a variety of changes:

* NPM Update (Vuetify + Vue + Fontawesome + devDependencies)
* Replace deprecated Vuetify component (`v-content` -> `v-main`)
* Fixed Regex Match Parser when global is deselected.
* Fixed issue with regex `flags` Vue syncing issue + fixed default value issue.
* Fixed Vue prop modification issue in `allGroupSettings` object + Fixed infinite loop update issue.
